### PR TITLE
Fixed repository link in 'about' comand

### DIFF
--- a/addons/info.py
+++ b/addons/info.py
@@ -17,7 +17,7 @@ class Info:
     @commands.command()
     async def about(self, ctx):
         """Information about the bot"""
-        await ctx.send("This is a bot coded in python for use in the PKSM server, made by Griffin#2329. You can view the source code [here](https://github.com/GriffinG1/PSKMBot).")
+        await ctx.send("This is a bot coded in python for use in the PKSM server, made by Griffin#2329. You can view the source code [here](https://github.com/GriffinG1/PKSMBot).")
         
 def setup(bot):
     bot.add_cog(Info(bot))


### PR DESCRIPTION
## Bug

When using ``.about``, the provided link was a typo of the actual repository.

## Changed

- Modified the ``.about`` command's repository link