### PR TITLE
more readme options

### DIFF
--- a/addons/info.py
+++ b/addons/info.py
@@ -60,11 +60,18 @@ class Info:
         await ctx.send("This is a bot coded in python for use in the PKSM server, made by {}#{}. You can view the source code here: <https://github.com/GriffinG1/PKSMBot>.".format(self.bot.creator.name, self.bot.creator.discriminator))    
     @commands.command()
     async def readme(self, ctx, app = ""):
-        """Here are the readmes you should read"""
-        if app.lower() == "script" or app.lower() == "pksmscript":
+        """Here are the readmes you should read
+        Available readmes: PKSM, PKSMScript (or scripts), serveLegality (or legality), servepkx, Sharkive"""
+        if app.lower() == "scripts" or app.lower() == "pksmscript":
             embed = discord.Embed(description="You can read about PKSM scripts [here](https://github.com/BernardoGiordano/PKSM-Tools/blob/master/PKSMScript/README.md).")
         elif app.lower() == "servelegality" or app.lower() == "legality":
             embed = discord.Embed(description="You can read serveLegality's readme [here](https://github.com/BernardoGiordano/PKSM-Tools/blob/master/serveLegality/README.md).")
+        elif app.lower() == 'servepkx' or app.lower() == 'servepkx-browser':
+            embed = discord.Embed(description="You can read servepkx's readme [here](https://github.com/BernardoGiordano/PKSM-Tools/blob/master/servepkx/servepkx-browser/README.md).")
+        elif app.lower() == 'servepkx-go':
+            embed = discord.Embed(description="You can read servepkx-go's readme [here](https://github.com/BernardoGiordano/PKSM-Tools/blob/master/servepkx/servepkx-go/README.md).")
+        elif app.lower() == 'servepkx-gui' or app.lower() == 'servepkx-java':
+            embed = discord.Embed(description="You can read servepkx-gui's readme [here](https://github.com/BernardoGiordano/PKSM-Tools/blob/master/servepkx/servepkx-gui/README.md).")
         elif app.lower() == "sharkive":
             embed = discord.Embed(description="You can read Sharkive's readme [here](https://github.com/BernardoGiordano/Sharkive/blob/master/README.md).")
         else:


### PR DESCRIPTION
Fixed it so `scripts` will bring up the **PKSMScript** readme and documented which readmes the command can bring up.

Also tried adding **servepkx**, but I'm not entirely pleased with it because of how many versions of the app there are and how many ways users might try to get its readme.

I considered doing it like below but not being familiar with Python, or your preferences on coding style, wasn't sure if it was acceptable
```python
elif 'pkx' in app.lower():
    if 'go' in app.lower():
        embed = discord.Embed(description="You can read servepkx-go's readme [here](https://github.com/BernardoGiordano/PKSM-Tools/blob/master/servepkx/servepkx-go/README.md).")
    elif 'gui' in app.lower() or 'java' in app.lower():
        embed = discord.Embed(description="You can read servepkx-gui's readme [here](https://github.com/BernardoGiordano/PKSM-Tools/blob/master/servepkx/servepkx-gui/README.md).")
    else:
        embed = discord.Embed(description="You can read servepkx's readme [here](https://github.com/BernardoGiordano/PKSM-Tools/blob/master/servepkx/servepkx-browser/README.md).")
```

And this still doesn't account for the 3 different versions of servepkx-go (Windows, Mac, Linux).