### PR TITLE
Add secure_role_mention command

### DIFF
--- a/addons/utility.py
+++ b/addons/utility.py
@@ -101,5 +101,26 @@ class Utility:
         except discord.errors.Forbidden:
             await ctx.send("{} Successfully toggled all possible roles.".format(ctx.author.mention), delete_after=5)
             
+    @commands.command()
+    @commands.guild_only()
+    @commands.has_any_role("Discord Moderator", "Flagbrew Team")
+    async def secure_role_mention(self, ctx, update_type: str, *, message=None):
+        """Securely mention an Updates role.
+
+        update_type must be any valid role that ends in Updates (ie. General updates has update_type set to General)."""
+
+        role = discord.utils.get(ctx.guild.roles, name=update_type + " Updates")
+        if not role:
+            return await ctx.send("This is not a valid Updates role!")
+
+        await role.edit(mentionable=True, reason="{} wanted to mention users with this role.".format(ctx.author)) # Reason -> Helps pointing out folks that abuse this
+
+        await ctx.send("{}".format(role.mention))
+        # Alternative way -> Remove =None from signature and comment the above line and uncomment the below two to use it.
+        #await ctx.send("**<{}#{}>**: {}".format(ctx.author.name, ctx.author.discriminator, message))
+        #await ctx.message.delete()
+
+        await role.edit(mentionable=False, reason="Making role unmentionable again.")
+
 def setup(bot):
     bot.add_cog(Utility(bot))

--- a/addons/utility.py
+++ b/addons/utility.py
@@ -104,21 +104,22 @@ class Utility:
     @commands.command()
     @commands.guild_only()
     @commands.has_any_role("Discord Moderator", "Flagbrew Team")
-    async def secure_role_mention(self, ctx, update_type: str, *, message=None):
+    async def secure_role_mention(self, ctx, update_type: str):
         """Securely mention an Updates role.
 
         update_type must be any valid role that ends in Updates (ie. General updates has update_type set to General)."""
 
-        role = discord.utils.get(ctx.guild.roles, name=update_type + " Updates")
+        role = discord.utils.get(ctx.guild.roles, name=update_type + " updates")
         if not role:
             return await ctx.send("This is not a valid Updates role!")
 
         await role.edit(mentionable=True, reason="{} wanted to mention users with this role.".format(ctx.author)) # Reason -> Helps pointing out folks that abuse this
 
+        chan_message = "🔔 Update was posted in {}\n".format(ctx.channel)
+        chan_message += "Updater was {} | {}".format(ctx.author, ctx.author.id)
+
+        await self.bot.logs_channel.send(chan_message)
         await ctx.send("{}".format(role.mention))
-        # Alternative way -> Remove =None from signature and comment the above line and uncomment the below two to use it.
-        #await ctx.send("**<{}#{}>**: {}".format(ctx.author.name, ctx.author.discriminator, message))
-        #await ctx.message.delete()
 
         await role.edit(mentionable=False, reason="Making role unmentionable again.")
 


### PR DESCRIPTION
This makes role mentions more secure by letting the bot mention the role, making the timeframe in which the role is
mentionable incredibly small, reducing the chances for abuse.

The idea is as follows:
- Write update message
- Do `.secure_role_mention PKSM` (or General or Checkpoint, PKSM is the example.
- The bot _temporarily_ makes this role mentionable.
- The bot sends a message of its own that just mentions the chosen role to the _same channel_.
- The bot makes the role unmentionable again.

This makes the effective timeframe for abuse less than a split second.