### PR TITLE
Guild only

### DIFF
--- a/addons/mod.py
+++ b/addons/mod.py
@@ -13,6 +13,7 @@ class Moderation:
         self.bot = bot
         print('Addon "{}" loaded'.format(self.__class__.__name__))
     
+    @commands.guild_only()
     @commands.has_permissions(kick_members=True)    
     @commands.command(pass_context=True)
     async def kick(self, ctx, member:discord.Member, *, reason="No reason was given."):
@@ -30,7 +31,8 @@ class Moderation:
                 pass # bot blocked or not accepting DMs
             await member.kick(reason=reason)
             await ctx.send("Successfully kicked user {0.name}#{0.discriminator}!".format(member))
-    
+
+    @commands.guild_only()
     @commands.has_permissions(ban_members=True)    
     @commands.command(pass_context=True)
     async def ban(self, ctx, member:discord.Member, *, reason="No reason was given."):
@@ -53,6 +55,7 @@ class Moderation:
             embed.set_image(url="https://i.imgur.com/tEBrxUF.jpg")
             await ctx.send("Successfully banned user {0.name}#{0.discriminator}!".format(member), embed=embed)
             
+    @commands.guild_only()
     @commands.has_permissions(ban_members=True)
     @commands.command(aliases=['p'])
     async def purge(self, ctx, amount=0):

--- a/addons/utility.py
+++ b/addons/utility.py
@@ -50,7 +50,7 @@ class Utility:
             await user.remove_roles(role)
             return True
         
-        
+    @commands.guild_only()
     @commands.command()
     async def togglerole(self, ctx, *, role=""):
         """Allows user to toggle update roles. You can use .masstoggle to apply all roles at once.
@@ -88,6 +88,7 @@ class Utility:
         except discord.errors.Forbidden:
             await ctx.send(ctx.author.mention + ' ' + info_string, delete_after=5)
             
+    @commands.guild_only()
     @commands.command()
     async def masstoggle(self, ctx):
         """Allows a user to toggle all possible update roles. Use .help toggleroles to see possible roles."""

--- a/main.py
+++ b/main.py
@@ -41,13 +41,6 @@ try:
 except KeyError:
     token = config['Main']['token']
     heroku = False
-    
-@bot.check # taken and modified from https://discordpy.readthedocs.io/en/rewrite/ext/commands/commands.html#global-checks
-async def globally_block_dms(ctx):
-    if ctx.guild is None:
-        raise discord.ext.commands.NoPrivateMessage('test')
-        return False
-    return True
         
 
 # mostly taken from https://github.com/Rapptz/discord.py/blob/async/discord/ext/commands/bot.py


### PR DESCRIPTION
This literally is piss easy.

This makes all commands that involve the Flagbrew discord `guild_only` while making information commands not `guild_only`, letting users use them in DMs.