### PR TITLE
New banid command + proper ban fix

### DIFF
--- a/addons/mod.py
+++ b/addons/mod.py
@@ -20,7 +20,6 @@ class Moderation:
         member -> discord.User object, can be limited.
         reason -> reason to ban
         """
-        reason += "\n\nAction done by {} (This is to deal with audit log scraping".format(ctx.author)
         if member.id == ctx.message.author.id:
             return await ctx.send("You can't ban yourself, obviously")
         else:
@@ -28,6 +27,7 @@ class Moderation:
                 await member.send("You were banned from FlagBrew for:\n\n`{}`\n\nIf you believe this to be in error, please contact a staff member".format(reason))
             except:
                 pass # bot blocked or not accepting DMs
+            reason += "\n\nAction done by {} (This is to deal with audit log scraping".format(ctx.author)
             try:
                 await ctx.guild.ban(member, delete_message_days=0, reason=reason)
             except discord.Forbidden: # i have no clue

--- a/addons/mod.py
+++ b/addons/mod.py
@@ -13,6 +13,27 @@ class Moderation:
         self.bot = bot
         print('Addon "{}" loaded'.format(self.__class__.__name__))
     
+    async def generic_ban_things(ctx, member):
+        """Generic stuff that is used by both ban commands.
+        
+        ctx -> Commands.Context object.
+        member -> discord.User object, can be limited.
+        """
+        if member.id == ctx.message.author.id:
+            return await ctx.send("You can't ban yourself, obviously")
+        else:
+            try:
+                await member.send("You were banned from FlagBrew for:\n\n`{}`\n\nIf you believe this to be in error, please contact a staff member".format(reason))
+            except:
+                pass # bot blocked or not accepting DMs
+            try:
+                await ctx.guild.ban(member, delete_message_days=0, reason=reason)
+            except discord.Forbidden: # i have no clue
+                return await ctx.send("I don't have permission. Why don't I have permission.")
+            embed = discord.Embed()
+            embed.set_image(url="https://i.imgur.com/tEBrxUF.jpg")
+            await ctx.send("Successfully banned user {0.name}#{0.discriminator}!".format(member), embed=embed)
+    
     @commands.has_permissions(kick_members=True)    
     @commands.command(pass_context=True)
     async def kick(self, ctx, member:discord.Member, *, reason="No reason was given."):
@@ -32,27 +53,23 @@ class Moderation:
     
     @commands.has_permissions(ban_members=True)    
     @commands.command(pass_context=True)
-    async def ban(self, ctx, member:discord.Member, *, reason="No reason was given."):
-        """Ban a member."""
-        if member == ctx.message.author:
-            return await ctx.send("You can't ban yourself, obviously")
-        else:
-            try:
-                await member.send("You were banned from FlagBrew for:\n\n`{}`\n\nIf you believe this to be in error, please contact a staff member".format(reason))
-            except:
-                pass # bot blocked or not accepting DMs
-            try:
-                await ctx.guild.ban(member, delete_message_days=0, reason=reason)
-            except discord.Forbidden: # i have no clue
-                try:
-                    reason += "\n\nAction done by {} (This is to deal with audit log scraping".format(ctx.author)
-                    await member.ban(reason=reason)
-                except discord.Forbidden: # none at all
-                    return await ctx.send("I don't have permission. Why don't I have permission.")
-            embed = discord.Embed()
-            embed.set_image(url="https://i.imgur.com/tEBrxUF.jpg")
-            await ctx.send("Successfully banned user {0.name}#{0.discriminator}!".format(member), embed=embed)
-            
+    async def ban(self, ctx, member:discord.User, *, reason="No reason was given."):
+        """Ban a user."""
+        if not member: # Edge case in which UserConverter may fail to get a User
+            return await ctx.send("Could not find user. They may no longer be in the global User cache. If you are sure this is a valid user, try `.banid` instead.")
+        await self.generic_ban_things(ctx, member)
+
+    @commands.has_permissions(ban_members=True)    
+    @commands.command(pass_context=True)
+    async def banid(self, ctx, member:int, *, reason="No reason was given."):
+        """Ban a user with their user ID.
+        
+        To get a user ID, enable developer mode and right click their profile."""
+        member = await self.bot.get_user_info(member)
+        if not member:
+            return await ctx.send("This is not a valid discord user.")
+        await self.generic_ban_things(ctx, member)
+
     @commands.has_permissions(ban_members=True)
     @commands.command(aliases=['p'])
     async def purge(self, ctx, amount=0):

--- a/addons/mod.py
+++ b/addons/mod.py
@@ -13,11 +13,12 @@ class Moderation:
         self.bot = bot
         print('Addon "{}" loaded'.format(self.__class__.__name__))
     
-    async def generic_ban_things(ctx, member):
+    async def generic_ban_things(ctx, member, reason):
         """Generic stuff that is used by both ban commands.
         
         ctx -> Commands.Context object.
         member -> discord.User object, can be limited.
+        reason -> reason to ban
         """
         if member.id == ctx.message.author.id:
             return await ctx.send("You can't ban yourself, obviously")
@@ -57,7 +58,7 @@ class Moderation:
         """Ban a user."""
         if not member: # Edge case in which UserConverter may fail to get a User
             return await ctx.send("Could not find user. They may no longer be in the global User cache. If you are sure this is a valid user, try `.banid` instead.")
-        await self.generic_ban_things(ctx, member)
+        await self.generic_ban_things(ctx, member, reason)
 
     @commands.has_permissions(ban_members=True)    
     @commands.command(pass_context=True)
@@ -68,7 +69,7 @@ class Moderation:
         member = await self.bot.get_user_info(member)
         if not member:
             return await ctx.send("This is not a valid discord user.")
-        await self.generic_ban_things(ctx, member)
+        await self.generic_ban_things(ctx, member, reason)
 
     @commands.has_permissions(ban_members=True)
     @commands.command(aliases=['p'])

--- a/addons/mod.py
+++ b/addons/mod.py
@@ -20,6 +20,7 @@ class Moderation:
         member -> discord.User object, can be limited.
         reason -> reason to ban
         """
+        reason += "\n\nAction done by {} (This is to deal with audit log scraping".format(ctx.author)
         if member.id == ctx.message.author.id:
             return await ctx.send("You can't ban yourself, obviously")
         else:

--- a/main.py
+++ b/main.py
@@ -61,7 +61,7 @@ async def on_command_error(ctx, error):
     elif isinstance(error, discord.ext.commands.NoPrivateMessage):
         await ctx.send("You cannot use this command in DMs! Please go to <#379201279479513100>")
     elif isinstance(error, discord.ext.commands.errors.BadArgument):
-        await ctx.send("A bad argument was provided, please try again. (If this happens with ban, right click for now. I have no clue what's causing this as I cannot reproduce outside of Flagbrew.")
+        await ctx.send("A bad argument was provided, please try again.")
     elif isinstance(error, discord.ext.commands.errors.CheckFailure):
         await ctx.send("You don't have permission to use this command.")
     else:


### PR DESCRIPTION
The reason the `ban` command failed is twofold.

1. The signature for `ban` makes use of a typing to discord.Member. This calls MemberConverter on the specified input. The difference between `discord.Member` and `discord.User` is that `discord.User` does not contain information specific to the guild, while `discord.Member` does. This changes the signature for `ban` to take a discord.User instead. Syntax input wise remains the same.

To accomodate, the call to `discord.Member.ban()` has been removed as `discord.Guild.ban()` accepts `discord.User` just fine.

2. That said, even when using UserConverter instead of MemberConverter, there might be a situation in which a user might no longer be in the available User cache and as a result will not resolve properly.

To accomodate for this, a new command is added called `banid` which takes a user ID. This makes use of `discord.Client.get_user_info()` to get a limited discord.User that will suffice enough for the actions done to ban a user.

To prevent code repetition, a new function called `generic_ban_things()` has been added that takes up most of the code that was originally in `ban()`.

`ban` also suggests to use banid, should UserConverter fail.