### PR TITLE
Added forgotten self to signature

### DIFF
--- a/addons/mod.py
+++ b/addons/mod.py
@@ -13,7 +13,7 @@ class Moderation:
         self.bot = bot
         print('Addon "{}" loaded'.format(self.__class__.__name__))
     
-    async def generic_ban_things(ctx, member, reason):
+    async def generic_ban_things(self, ctx, member, reason):
         """Generic stuff that is used by both ban commands.
         
         ctx -> Commands.Context object.


### PR DESCRIPTION
This function needs a self, forgot to add it to the function signature.

This should fix ban _properly_ (full on me, this was a basic python syntax issue I overlooked).